### PR TITLE
Added the ability to send error mails

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,21 @@
+{
+    "browser": true,
+    "esnext": true,
+    "globals": {},
+    "globalstrict": true,
+    "quotmark": "single",
+    "undef": true,
+    "unused": true,
+    "node": true,
+    "mocha": true,
+    "laxbreak": true,
+    "curly": true,
+    "eqeqeq": true,
+    "latedef": false,
+    "immed": true,
+    "maxdepth": 4,
+    "maxlen": 120,
+    "shadow": "outer",
+    "elision": true,
+    "expr": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ install:
   - "export TRAVIS=1"
 language: node_js
 node_js:
-  - "5.0.0"
+  - "6.0.0"
+  - "7.0.0"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,48 @@
+'use strict';
+
+
+module.exports = (grunt) => {
+
+    grunt.initConfig({
+        jshint: {
+            files: [
+                'Gruntfile.js',
+                'index.js',
+                'lib/**/*.js',
+                'test/**/*.js'
+            ],
+            options: {
+                jshintrc: '.jshintrc'
+            }
+        },
+
+        mochaTest: {
+            test: {
+                src: ['test/**/*.js'],
+                options: {
+                    reporter: 'spec',
+                    timeout: 5000
+                }
+            }
+        },
+
+        watch: {
+          lib: {
+            files: ['<%= jshint.files %>'],
+            tasks: ['jshint'],
+            options: {
+                spawn: false
+            }
+          }
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-mocha-test');
+
+    grunt.registerTask('test', ['jshint', 'mochaTest']);
+    grunt.registerTask('test-watch', ['jshint', 'mochaTest', 'watch']);
+    grunt.registerTask('default', ['jshint', 'watch']);
+
+};

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 [![npm version](https://badge.fury.io/js/anytv-node-error-handler.svg)](https://badge.fury.io/js/anytv-node-error-handler)
 
 Our error handler middleware for expressjs. Especially made for our awesome expressjs [boilerplate](https://github.com/anyTV/anytv-node-boilerplate).
+Capable of sending email for every unique error.
 
 
 # Install
 
 ```sh
-npm install anytv-node-error-handler --save
+npm i anytv-node-error-handler -S
 ```
 
 
@@ -25,8 +26,54 @@ import express from 'express';
 
 app = express();
 
-app.use(error_handler(logger));
+app.use(error_handler(logger, mailer, {
+    unique: true,                   // optional defaults to true
+    to: 'dev@mail.com',             // required if mailer is present
+    from: 'app@mail.com',           // required if mailer is present
+    subject: 'MyApp > Server Error' // required if mailer is present
+    pretend: false                  // optional, set to true to pretending sending of emails
+}));
 ```
+
+`mailer` - should be an instance of [anytv-mailer](https://github.com/anytv/anytv-mailer)
+
+
+# Setting up the mailer
+1. Make sure mailer is already configured
+2. Create a template for the error, `${ TEMPLATES_DIR }/error/html.ejs`
+3. `err` object will be passed onto the template you can render it using `<%- JSON.stringify(err, null, '\t') ->`
+4. When calling the `next` function on controllers, pass an `_key`, it will serve as the unique key for the error. See samples:
+```js
+// 1. When catching query errors
+function send_response (err, result) {
+
+    if (err) {
+        winston.error('Error in getting data', err);
+        // append the sql error code to make it mail different sql errors
+        err._key = 'get_data_query_' + err.code;
+        return next(err);
+    }
+
+    res.send(result);
+}
+
+
+// 2. When catching a normal error
+function send_response (err, result) {
+
+    if (err) {
+        winston.error('Error in generating earnings', err);
+        err._key = 'earnings_generation';
+        return next(err);
+    }
+
+    res.send(result);
+}
+
+```
+
+Note: Restarting the server will clear the map of unique errors.
+Make sure to fix it first or remove the `_key` to avoid sending identical emails.
 
 
 # Contributing

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,21 +1,47 @@
 'use strict';
 
-module.exports = (logger) => {
+const unique_keys = {};
 
-    if (!logger) {
-        throw new Error('Logger is missing');
-    }
 
-    if (!logger.warn || !logger.error) {
-        throw new Error('Logger is missing warn or error function');
-    }
+module.exports = function (logger, mailer, opts = {}) {
 
-    return (err, req, res, next) => {
-        const error = err.message || err.data || err;
 
-        if (!(err instanceof Error)) {
-            err = new Error(err);
+    function start () {
+
+        if (!('unique' in opts)) {
+            opts.unique = true;
         }
+
+        if (!logger) {
+            throw new Error('Logger is missing');
+        }
+
+        if (!logger.warn || !logger.error) {
+            throw new Error('Logger is missing warn or error function');
+        }
+
+        if (mailer) {
+
+            if (!opts.to) {
+                throw new Error('Error mailer does not have a recipient');
+            }
+
+            if (!opts.from) {
+                throw new Error('Error mailer does not have a sender');
+            }
+
+            if (!opts.subject) {
+                throw new Error('Error mailer does not have a subject');
+            }
+        }
+
+        return middleware;
+    }
+
+
+    function middleware (err, req, res, next) { // jshint ignore:line
+
+        const error = err.message || err.data || err;
 
         logger.error(error);
 
@@ -31,8 +57,44 @@ module.exports = (logger) => {
             logger.error(err.stack);
         }
 
-        return res.status(500)
-                .send({message: error});
-    };
+        res.status(500)
+            .send({message: error});
 
+
+        if (!err._key || !mailer) {
+            return false;
+        }
+
+        if (unique_keys[err._key]) {
+            unique_keys[err._key]++;
+            return false;
+        }
+
+        if (opts.pretend) {
+            logger.warn('Pretending to send error mail');
+            return false;
+        }
+
+        unique_keys[err._key] = 1;
+
+        mailer.send_mail
+            .to(opts.to)
+            .from(opts.from)
+            .subject(opts.subject)
+            .template('error')
+            .content({err})
+            .then(check_email_sent);
+
+        return true;
+    }
+
+
+    function check_email_sent (err) {
+
+        if (err) {
+            logger.error(`Error in sending error email`, err);
+        }
+    }
+
+    return start();
 };

--- a/package.json
+++ b/package.json
@@ -1,8 +1,14 @@
 {
   "name": "anytv-node-error-handler",
-  "version": "0.0.10",
+  "version": "1.0.0",
   "description": "Express error handler middleware",
   "main": "index.js",
+  "files": [
+    "LICENSE",
+    "README.md",
+    "index.js",
+    "lib/index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/anyTV/anytv-node-error-handler.git"
@@ -20,15 +26,23 @@
   },
   "homepage": "https://github.com/anyTV/anytv-node-error-handler",
   "devDependencies": {
-    "istanbul": "^0.4.0",
-    "chai": "^3.4.1",
-    "coveralls": "^2.11.4",
-    "mocha": "^2.3.3",
-    "mocha-lcov-reporter": "^1.0.0"
+    "anytv-mailer": "^1.0.0",
+    "chai": "^4.0.2",
+    "coveralls": "^2.13.1",
+    "grunt": "^1.0.1",
+    "grunt-contrib-jshint": "^1.1.0",
+    "grunt-contrib-watch": "^1.0.0",
+    "grunt-mocha-test": "^0.13.2",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.4.2",
+    "mocha-lcov-reporter": "^1.3.0"
   },
   "scripts": {
     "test": "make test",
     "coverage": "export NODE_ENV=test && istanbul cover _mocha -- --recursive -R spec -t 5000 -s 100",
     "test-dev": "export NODE_ENV=test && mocha --watch --recursive -R spec -t 5000 -s 100"
+  },
+  "dependencies": {
+    "anytv-mailer": "^1.0.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,27 @@
 'use strict';
 
-const should = require('chai').should();
 const middleware = require(process.cwd() + '/index');
+const should = require('chai').should(); // jshint ignore:line
+const mailer = require('anytv-mailer');
 
 
 describe('Overall test', () => {
+
+    const noop_logger = {
+        warn: () => {},
+        error: () => {}
+    };
+
+    mailer.configure({
+        smtp_relay: {},
+        templates_dir: process.cwd(),
+        i18n: {
+            trans: () => {}
+        }
+    });
+
+
+
 
     it ('middleware should require a logger', (done) => {
         (() => {
@@ -13,6 +30,7 @@ describe('Overall test', () => {
 
         done();
     });
+
 
     it ('middleware should require error and warn function in logger', (done) => {
         // both missing
@@ -32,24 +50,20 @@ describe('Overall test', () => {
 
         // no missing
         (() => {
-            middleware({
-                warn: () => {},
-                error: () => {}
-            });
+            middleware(noop_logger);
         }).should.not.throw(Error, 'Logger is missing warn or error function');
 
         done();
     });
 
+
     it ('middleware should return a function', (done) => {
 
-        middleware({
-            warn: () => {},
-            error: () => {}
-        }).should.be.a('function');
+        middleware(noop_logger).should.be.a('function');
 
         done();
     });
+
 
     it ('middleware should log the error', (done) => {
 
@@ -62,9 +76,107 @@ describe('Overall test', () => {
             {},
             {
                 status: () => {
-                    return {send: (halo) => done()};
+                    return {send: () => done()};
                 }
             });
+    });
+
+
+    it ('middleware should require recipient if mailer is set', done => {
+
+        (() => {
+            middleware(noop_logger, mailer);
+        }).should.throw(Error, 'Error mailer does not have a recipient');
+
+        done();
+    });
+
+
+    it ('middleware should require sender if mailer is set', done => {
+
+        (() => {
+            middleware(noop_logger, mailer, {to: 'foo@bar.com'});
+        }).should.throw(Error, 'Error mailer does not have a sender');
+
+        done();
+    });
+
+
+    it ('middleware should require subject if mailer is set', done => {
+
+        (() => {
+            middleware(noop_logger, mailer, {to: 'foo@bar.com', from: 'bar@foo.com'});
+        }).should.throw(Error, 'Error mailer does not have a subject');
+
+        done();
+    });
+
+
+    it ('middleware should require subject if mailer is set', done => {
+
+        (() => {
+            middleware(noop_logger, mailer, {to: 'foo@bar.com', from: 'bar@foo.com'});
+        }).should.throw(Error, 'Error mailer does not have a subject');
+
+        done();
+    });
+
+
+    it ('middleware should send an email if error has key', done => {
+
+        const fn = middleware(
+            noop_logger,
+            mailer,
+            {
+                to: 'foo@bar.com',
+                from: 'bar@foo.com',
+                subject: 'my email error subject'
+            }
+        );
+
+        const is_email_sent = fn(
+            {
+                message: 'this is the error',
+                _key: 'my_unique_key'
+            },
+            {},
+            {
+                status: () => ({send: () => {}})
+            }
+        );
+
+        is_email_sent.should.equal(true);
+
+        done();
+    });
+
+
+    it ('middleware should not send an email if key is the same', done => {
+
+        const fn = middleware(
+            noop_logger,
+            mailer,
+            {
+                to: 'foo@bar.com',
+                from: 'bar@foo.com',
+                subject: 'my email error subject'
+            }
+        );
+
+        let is_email_sent = fn(
+            {
+                message: 'this is the error',
+                _key: 'my_unique_key'
+            },
+            {},
+            {
+                status: () => ({send: () => {}})
+            }
+        );
+
+        is_email_sent.should.equal(false);
+
+        done();
     });
 
 });


### PR DESCRIPTION
Will be used in: https://freedom.myjetbrains.com/youtrack/issue/Dev-1662
- to send an email whenever it failed creating a ticket on Zendesk
- since the solution is done on the library, it can also help other projects

Changes:
- Added ability to send error emails
- Updated README.md for instructions on how to setup error mailer
- Added gruntfile to lint code
- Updated packages

How to test:
1. clone repo
2. `npm i --dev`
3. `npm test`